### PR TITLE
don't return just a slash when no package source available, fixes #15

### DIFF
--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -38,6 +38,10 @@ class Package extends EntityBase {
     
     public function getSource()
     {
+        if(! $this->source){
+            return null;
+        }
+
         return dirname($this->source)."/".basename($this->source, '.git');
     }
     


### PR DESCRIPTION
Fixes https://github.com/bolt/bolt-extensions/issues/15 and makes the submit form much clearer.