### PR TITLE
Add wikimedia/composer-merge-plugin as a repository

### DIFF
--- a/src/Command/Satis.php
+++ b/src/Command/Satis.php
@@ -46,6 +46,8 @@ class Satis extends Command
         foreach ($packages as $package) {
             $repo['repositories'][] = ['type' => 'vcs', 'url' => $package->source];
         }
+        $repo['repositories'][] = ['type'=>'vcs', 'url'=> 'https://github.com/wikimedia/composer-merge-plugin.git'];
+
         $satis = json_encode($repo);
         $file = getcwd() . "/satis.json";
         $result = file_put_contents($file, $satis);


### PR DESCRIPTION
This is used for local extension autoloading functionality in v3.

It has no effect on v2 use/sites, and will only appear in the Satis list, not the public extension list.