### PR TITLE
change stackable to doubling for theme cards grid on the homepage

### DIFF
--- a/src/Templates/index.html
+++ b/src/Templates/index.html
@@ -64,7 +64,7 @@
     <h2 class="ui left floated header">Recently Added Themes</h2>
     <div class="ui clearing divider"></div>
 
-    <div class="ui three column grid stackable">
+    <div class="ui three column grid doubling">
 
         {% for package in latest_themes %}
         <div class="column">
@@ -106,7 +106,7 @@
     <h2 class="ui left floated header">Most Downloaded Themes</h2>
     <div class="ui clearing divider"></div>
 
-    <div class="ui three column grid stackable">
+    <div class="ui three column grid doubling"">
 
         {% for package in mdownloaded_themes |slice(0, 6) %}
         <div class="column">


### PR DESCRIPTION
On mobile view, the theme card was stretched over the full width. With the height limited to 150px, it looked a bit weird. Now there are two themes in a row on mobile and tablet.

On the `Recently Added Themes` section, there is one empty column now, because there are only 3 themes at all. But I think that is ok.

Screenshots from tablet/mobile view:
https://infinit.io/_/fFJKqFc
https://infinit.io/_/MMJVfpX