### PR TITLE
Load package versions via Ajax to speed things up

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -22,6 +22,8 @@ $router->add("edit", "/edit/{package}")->setValues(['action'=>'Bolt\Extensions\A
 $router->add("view", "/view/{package}")->setValues(['action'=>'Bolt\Extensions\Action\ViewPackage']);
 $router->add("disable", "/disable/{package}")->setValues(['action'=>'Bolt\Extensions\Action\DisablePackage']);
 
+$router->add("releases", "/view/{package}/releases")->setValues(['action'=>'Bolt\Extensions\Action\Releases']);
+
 $router->add("search", "/search")->setValues(['action'=>'Bolt\Extensions\Action\Search', 'type'=>'search']);
 $router->add("jsonsearch", "/search.json")->setValues(['action'=>'Bolt\Extensions\Action\JsonSearch']);
 $router->add("browse", "/browse")->setValues(['action'=>'Bolt\Extensions\Action\Search', 'type'=>'browse']);

--- a/public/js/extension-extras.js
+++ b/public/js/extension-extras.js
@@ -13,7 +13,6 @@ jQuery(document).ready(function($) {
 	  	url: "/view/" + packageID + "/releases",
 	  	context: $('.releases-wrapper')
 	}).done(function(response) {
-		console.log(response);
 	  	$(this).html(response);
 	});
 });

--- a/public/js/extension-extras.js
+++ b/public/js/extension-extras.js
@@ -3,9 +3,17 @@ jQuery(document).ready(function($) {
     $('.ui.toggle.button').popup();
     $('.ui.accordion').accordion();
     $('.scrollbar-inner').scrollbar();
-    
+
     var client = new ZeroClipboard( document.getElementById("copy-button") );
     client.on( "ready", function( readyEvent ) {
-        
+
     });
+
+    $.ajax({
+	  	url: "/view/" + packageID + "/releases",
+	  	context: $('.releases-wrapper')
+	}).done(function(response) {
+		console.log(response);
+	  	$(this).html(response);
+	});
 });

--- a/public/js/extension-extras.js
+++ b/public/js/extension-extras.js
@@ -14,5 +14,6 @@ jQuery(document).ready(function($) {
 	  	context: $('.releases-wrapper')
 	}).done(function(response) {
 	  	$(this).html(response);
+	  	$('.ui.accordion').accordion();
 	});
 });

--- a/src/Action/Releases.php
+++ b/src/Action/Releases.php
@@ -1,0 +1,69 @@
+<?php
+namespace Bolt\Extensions\Action;
+
+use Aura\Router\Router;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Composer\Util\ConfigValidator;
+use Composer\IO\NullIO;
+use Twig_Environment;
+use Doctrine\ORM\EntityManager;
+use Bolt\Extensions\Entity;
+use Bolt\Extensions\Service\PackageManager;
+
+
+class Releases
+{
+
+    public $renderer;
+    public $em;
+    public $packageManager;
+    public $router;
+
+    public function __construct(Twig_Environment $renderer, EntityManager $em, PackageManager $packageManager, Router $router)
+    {
+        $this->renderer = $renderer;
+        $this->em = $em;
+        $this->packageManager = $packageManager;
+        $this->router = $router;
+    }
+
+    public function __invoke(Request $request, $params)
+    {
+        $repo = $this->em->getRepository(Entity\Package::class);
+        $package = $repo->findOneBy(['id'=>$params['package']]);
+
+        if(!$package) {
+            $request->getSession()->getFlashBag()->add('error', "There was a problem accessing this package");
+            return new RedirectResponse($this->router->generate('profile'));
+        }
+
+        $versions = ['dev'=>[],'stable'=>[]];
+
+        try {
+            $repo = $this->em->getRepository(Entity\VersionBuild::class);
+            $info = $this->packageManager->getInfo($package, false);
+            foreach($info as $ver) {
+                $build = $repo->findOneBy(['package'=>$package->id, 'version'=>$ver['version']]);
+                if($build) {
+                    $ver['build'] = $build;
+                }
+                $versions[$ver['stability']][] = $ver;
+            }
+        } catch (\Exception $e) {
+            $request->getSession()->getFlashBag()->add('error', $e->getMessage());
+        }
+
+        return new Response(
+            $this->renderer->render(
+                "releases.html",
+                [
+                    'package' => $package,
+                    'versions' => $versions
+                ]
+            )
+        );
+
+    }
+}

--- a/src/Action/ViewPackage.php
+++ b/src/Action/ViewPackage.php
@@ -43,30 +43,14 @@ class ViewPackage
             return new RedirectResponse($this->router->generate('profile'));
         }
 
-        $versions = ['dev'=>[],'stable'=>[]];
         $allowedit = $package->account === $request->get('user');
         $readme = $this->packageManager->getReadme($package);
-
-        try {
-            $repo = $this->em->getRepository(Entity\VersionBuild::class);
-            $info = $this->packageManager->getInfo($package, false);
-            foreach($info as $ver) {
-                $build = $repo->findOneBy(['package'=>$package->id, 'version'=>$ver['version']]);
-                if($build) {
-                    $ver['build'] = $build;
-                }
-                $versions[$ver['stability']][] = $ver;
-            }
-        } catch (\Exception $e) {
-            $request->getSession()->getFlashBag()->add('error', $e->getMessage());
-        }
 
         return new Response(
             $this->renderer->render(
                 "view.html",
                 [
                     'package' => $package,
-                    'versions' => $versions,
                     'readme' => $readme,
                     'allowedit' => $allowedit,
                     'boltthemes' => $this->themeservice->info($package)

--- a/src/Templates/releases.html
+++ b/src/Templates/releases.html
@@ -1,0 +1,13 @@
+{% for version in versions.stable %}
+    <div class="title">
+        <i class="dropdown icon"></i>{{version.version}} Released: {{ version.time|date('jS F Y') }} (for Bolt {{version.require['bolt/bolt']}})
+    </div>
+    <div class="content">
+        {% if version.release.body %}
+            <pre>{{ version.release.body }}</pre>
+        {% else %}
+            <p><strong>No release information available</strong></p>
+            <p><a href="{{version.support.source}}">View source code</a> for this release</p>
+        {% endif %}
+    </div>
+{% endfor %}

--- a/src/Templates/releases.html
+++ b/src/Templates/releases.html
@@ -1,13 +1,15 @@
-{% for version in versions.stable %}
-    <div class="title">
-        <i class="dropdown icon"></i>{{version.version}} Released: {{ version.time|date('jS F Y') }} (for Bolt {{version.require['bolt/bolt']}})
-    </div>
-    <div class="content">
-        {% if version.release.body %}
-            <pre>{{ version.release.body }}</pre>
-        {% else %}
-            <p><strong>No release information available</strong></p>
-            <p><a href="{{version.support.source}}">View source code</a> for this release</p>
-        {% endif %}
-    </div>
-{% endfor %}
+<div class="ui accordion styled fluid gbody">
+    {% for version in versions.stable %}
+        <div class="title">
+            <i class="dropdown icon"></i>{{version.version}} Released: {{ version.time|date('jS F Y') }} (for Bolt {{version.require['bolt/bolt']}})
+        </div>
+        <div class="content">
+            {% if version.release.body %}
+                <pre>{{ version.release.body }}</pre>
+            {% else %}
+                <p><strong>No release information available</strong></p>
+                <p><a href="{{version.support.source}}">View source code</a> for this release</p>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>

--- a/src/Templates/view.html
+++ b/src/Templates/view.html
@@ -144,21 +144,8 @@
             <h2 class="ui left floated header">Changelog &amp; Releases</h2>
             <div class="ui clearing divider"></div>
 
-
-            <div class="ui accordion styled fluid gbody">
-                {% for version in versions.stable %}
-                    <div class="title">
-                        <i class="dropdown icon"></i>{{version.version}} Released: {{ version.time|date('jS F Y') }} (for Bolt {{version.require['bolt/bolt']}})
-                    </div>
-                    <div class="content">
-                        {% if version.release.body %}
-                            <pre>{{ version.release.body }}</pre>
-                        {% else %}
-                            <p><strong>No release information available</strong></p>
-                            <p><a href="{{version.support.source}}">View source code</a> for this release</p>
-                        {% endif %}
-                    </div>
-                {% endfor %}
+            <div class="releases-wrapper">
+                Loading releases ...
             </div>
         </div>
 
@@ -195,6 +182,10 @@
 {% endblock %}
 
 {% block header_extra_scripts %}
+<script>
+    var packageID = "{{ package.id}}";
+</script>
+
 <script src="/js/jquery.scrollbar.min.js"></script>
 <script src="//cdn.jsdelivr.net/zeroclipboard/2.2.0/ZeroClipboard.min.js"></script>
 <script src="/js/extension-extras.js"></script>

--- a/src/Templates/view.html
+++ b/src/Templates/view.html
@@ -183,7 +183,7 @@
 
 {% block header_extra_scripts %}
 <script>
-    var packageID = "{{ package.id}}";
+    var packageID = "{{package.id}}";
 </script>
 
 <script src="/js/jquery.scrollbar.min.js"></script>


### PR DESCRIPTION
Asking the Github Api for the latest versions takes very very long. I outsourced that to an extra route to load it via Ajax. Speed improvements should be up to 50% or more.